### PR TITLE
Fix/remove authentication from nlp info endpoint

### DIFF
--- a/bothub/api/v2/evaluate/views.py
+++ b/bothub/api/v2/evaluate/views.py
@@ -194,11 +194,15 @@ class ResultsListViewSet(
         try:
             results_ids_to_compare = request.query_params.get("ids", "").split(",")
             results = self.get_queryset().filter(pk__in=results_ids_to_compare)
-            serializer = RepositoryEvaluateResultSerializer(results, many=True, context={"request": request})
+            serializer = RepositoryEvaluateResultSerializer(
+                results, many=True, context={"request": request}
+            )
         except ValueError:
             return Response(
-                {"detail": "Send only integers in the 'ids' parameter. If there is a ',' left, remove it."},
-                400
+                {
+                    "detail": "Send only integers in the 'ids' parameter. If there is a ',' left, remove it."
+                },
+                400,
             )
 
         return Response(serializer.data, 200)

--- a/bothub/api/v2/nlp/views.py
+++ b/bothub/api/v2/nlp/views.py
@@ -268,7 +268,7 @@ class RepositoryAuthorizationInfoViewSet(mixins.RetrieveModelMixin, GenericViewS
     queryset = RepositoryAuthorization.objects
     serializer_class = NLPSerializer
     permission_classes = [AllowAny]
-    authentication_classes = [NLPAuthentication]
+    authentication_classes = []
 
     def retrieve(self, request, *args, **kwargs):
         check_auth(request)

--- a/bothub/api/v2/routers.py
+++ b/bothub/api/v2/routers.py
@@ -61,10 +61,10 @@ class Router(routers.SimpleRouter):
         # Dynamically generated list routes. Generated using
         # @action(detail=False) decorator on methods of the viewset.
         routers.DynamicRoute(
-            url=r'^{prefix}/{url_path}{trailing_slash}$',
-            name='{basename}-{url_name}',
+            url=r"^{prefix}/{url_path}{trailing_slash}$",
+            name="{basename}-{url_name}",
             detail=False,
-            initkwargs={}
+            initkwargs={},
         ),
         # Dynamically generated list routes.
         # Generated using @action decorator

--- a/bothub/api/v2/tests/test_evaluate.py
+++ b/bothub/api/v2/tests/test_evaluate.py
@@ -988,7 +988,9 @@ class CompareEvaluateResultsTestCase(TestCase):
         ids = f"{RepositoryEvaluateResult.objects.first().pk},{RepositoryEvaluateResult.objects.last().pk}"
         authorization_header = {"HTTP_AUTHORIZATION": "Token {}".format(token.key)}
         request = self.factory.get(
-            "/v2/evaluate/results/compare_results/?repository_uuid={}&ids={}".format(self.repository.uuid, ids),
+            "/v2/evaluate/results/compare_results/?repository_uuid={}&ids={}".format(
+                self.repository.uuid, ids
+            ),
             **authorization_header,
         )
         response = ResultsListViewSet.as_view({"get": "compare_results"})(
@@ -1005,5 +1007,9 @@ class CompareEvaluateResultsTestCase(TestCase):
 
     def test_compare_two_results(self):
         response, content_data = self.request(self.owner_token)
-        self.assertEqual(RepositoryEvaluateResult.objects.last().pk, response.data[1].get("id"))
-        self.assertEqual(RepositoryEvaluateResult.objects.first().pk, response.data[0].get("id"))
+        self.assertEqual(
+            RepositoryEvaluateResult.objects.last().pk, response.data[1].get("id")
+        )
+        self.assertEqual(
+            RepositoryEvaluateResult.objects.first().pk, response.data[0].get("id")
+        )

--- a/bothub/api/v2/tests/test_nlp.py
+++ b/bothub/api/v2/tests/test_nlp.py
@@ -196,10 +196,6 @@ class AuthorizationInfoTestCase(TestCase):
         response, content_data = self.request(str(self.repository_authorization.uuid))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_not_auth(self):
-        response, content_data = self.request(str(uuid.uuid4()))
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
     def test_list_all_repository_intents(self):
         response, content_data = self.request(str(self.repository_authorization.uuid))
         self.assertEqual(len(response.data.get("intents")), 1)

--- a/bothub/common/models.py
+++ b/bothub/common/models.py
@@ -386,7 +386,8 @@ class Repository(models.Model):
     def have_at_least_twenty_examples_for_each_intent(self, language: str) -> bool:
         return all(
             [
-                self.examples(language=language).filter(intent__text=intent).count() >= 20
+                self.examples(language=language).filter(intent__text=intent).count()
+                >= 20
                 for intent in self.intents()
             ]
         )


### PR DESCRIPTION
Removing the authentication class (NLPAuthentication) that is not used in that specific CBV (RepositoryAuthorizationInfoViewSet). also removing the test for that authentication.
