### PR TITLE
Sending welcome to bothub is only sent when the account is created by the rest api

### DIFF
--- a/bothub/api/v2/account/serializers.py
+++ b/bothub/api/v2/account/serializers.py
@@ -26,14 +26,16 @@ class RegisterUserSerializer(serializers.ModelSerializer):
         write_only=True, validators=[validate_password], label=_("Password")
     )
 
-    def create(self, validated_data):
-        validated_data.pop("recaptcha")
-        return super().create(validated_data)
-
     class Meta:
         model = User
         fields = ["email", "name", "nickname", "password", "recaptcha"]
         ref_name = None
+
+    def create(self, validated_data):
+        validated_data.pop("recaptcha")
+        instance = super().create(validated_data)
+        instance.send_welcome_email()
+        return instance
 
     @staticmethod
     def validate_password(value):

--- a/bothub/authentication/models.py
+++ b/bothub/authentication/models.py
@@ -195,9 +195,3 @@ class User(AbstractBaseUser, RepositoryOwner, PermissionsMixin):
                 role=OrganizationAuthorization.LEVEL_NOTHING
             ).values_list("organization", flat=True)
         )
-
-
-@receiver(models.signals.post_save, sender=User)
-def send_welcome_email(instance, created, **kwargs):
-    if created:
-        instance.send_welcome_email()

--- a/bothub/settings.py
+++ b/bothub/settings.py
@@ -484,7 +484,7 @@ if OIDC_ENABLED:
         "OIDC_DRF_AUTH_BACKEND",
         default="bothub.authentication.authorization.WeniOIDCAuthenticationBackend",
     )
-    OIDC_RP_SCOPES = env.str("OIDC_RP_SCOPES", default='openid email')
+    OIDC_RP_SCOPES = env.str("OIDC_RP_SCOPES", default="openid email")
 
 
 # gRPC Connect Server


### PR DESCRIPTION
It was observed that when using the OIDC middleware, an email was sent to the user, and this behavior is only expected on connect, in order to avoid this duplication of emails, I chose to send the welcome email only for when a user is created by the rest api