### PR TITLE
Hotfix/fix examples filter

### DIFF
--- a/bothub/api/v2/examples/filters.py
+++ b/bothub/api/v2/examples/filters.py
@@ -108,7 +108,7 @@ class ExamplesFilter(filters.FilterSet):
             if not authorization.can_translate:
                 raise PermissionDenied()
             if request.query_params.get("repository_version"):
-                return repository.examples(queryset=queryset, version_default=False)
+                return queryset
             return repository.examples(queryset=queryset)
         except Repository.DoesNotExist:
             raise NotFound(_("Repository {} does not exist").format(value))


### PR DESCRIPTION
Remove the line 111 because if you pass version_default=False, you'll need to pass a repository version for it to work. Instead of repository.examples, now it returns the queryset to be filtered later in the filter_repository_version