### PR TITLE
filter only classifier repositories at repository_score task

### DIFF
--- a/bothub/common/tasks.py
+++ b/bothub/common/tasks.py
@@ -365,7 +365,7 @@ def auto_translation(
 
 @app.task()
 def repository_score():  # pragma: no cover
-    for version in RepositoryVersion.objects.filter(is_default=True):
+    for version in RepositoryVersion.objects.filter(is_default=True, repository__repository_type="classifier"):
         dataset = {}
         intents = []
         train = {}


### PR DESCRIPTION
**What**

- In repository_score, update the filter to get only classifier repositories

**Why**

- The task was throwing errors when it tried to calculate a score of a content repository, as it is very different from classifiers and does not have the concept of a score