### PR TITLE
Chore/ Add debug toolbar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN pip install poetry==1.1.12
 RUN pip install gunicorn==19.9.0
 RUN pip install gevent==1.4.0
 RUN pip install psycopg2-binary
+RUN pip install django-debug-toolbar
+
 RUN apt-get install -y libjpeg-dev libgpgme-dev linux-libc-dev musl-dev libffi-dev libssl-dev
 ENV LIBRARY_PATH=/lib:/usr/lib
 

--- a/bothub/settings.py
+++ b/bothub/settings.py
@@ -148,6 +148,7 @@ INSTALLED_APPS = [
     "django_grpc_framework",
     "django_elasticsearch_dsl",
     "django_elasticsearch_dsl_drf",
+    "debug_toolbar",
 ]
 
 MIDDLEWARE = [
@@ -155,6 +156,7 @@ MIDDLEWARE = [
     "elasticapm.contrib.django.middleware.Catch404Middleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "csp.middleware.CSPMiddleware",
@@ -626,3 +628,15 @@ ELASTICSEARCH_DSL_SIGNAL_PROCESSOR = ELASTICSEARCH_SIGNAL_PROCESSOR_CLASSES[
 ]
 
 REPOSITORY_BLOCK_USER_LOGS = env.list("REPOSITORY_BLOCK_USER_LOGS", default=[])
+
+# Django Debug Toolbar
+INTERNAL_IPS = [
+    "127.0.0.1",
+    "0.0.0.0",
+]
+
+def show_toolbar(request):
+    return DEBUG
+DEBUG_TOOLBAR_CONFIG = {
+    "SHOW_TOOLBAR_CALLBACK" : show_toolbar,
+}

--- a/bothub/urls.py
+++ b/bothub/urls.py
@@ -122,3 +122,6 @@ if settings.DEBUG:
             ),
         )
     ]
+    urlpatterns += [
+        path('__debug__/', include('debug_toolbar.urls'))
+    ]


### PR DESCRIPTION
- The debug toolbar is a development-only tool, and it is enabled as such.
It allows for detailed query visualization and timing, requests headers, history and timing, and many other tools.

Is is specially useful for visualizing unnecessary and suboptimal queries that require improvement.