### PR TITLE
Fix/repository user authorization

### DIFF
--- a/bothub/common/models.py
+++ b/bothub/common/models.py
@@ -911,9 +911,13 @@ class Repository(models.Model):
         )
         if self.owner.is_organization:
             org_auth = self.owner.organization.get_organization_authorization(user)
-            if repo_auth.role < org_auth.role:
-                return org_auth
-
+            
+            # Excluding ROLE_TRANSLATE as it does not correspond to the same role in the client app (connect).
+            # todo: update this conditional with corresponding role rule
+            if repo_auth.role < org_auth.role\
+                and org_auth.role < RepositoryAuthorization.ROLE_TRANSLATE:
+                    repo_auth.role = org_auth.role
+                    repo_auth.save(update_fields=['role'])
         return repo_auth
 
     def get_absolute_url(self):

--- a/bothub/common/models.py
+++ b/bothub/common/models.py
@@ -906,16 +906,15 @@ class Repository(models.Model):
     def get_user_authorization(self, user):
         if user.is_anonymous:
             return RepositoryAuthorization(repository=self)
-        get, created = RepositoryAuthorization.objects.get_or_create(
+        repo_auth, created = RepositoryAuthorization.objects.get_or_create(
             user=user.repository_owner, repository=self
         )
         if self.owner.is_organization:
-            org_role = self.owner.organization.get_organization_authorization(user).role
-            if get.role != org_role and get.role == 0:
-                get.role = org_role
-                get.save()
+            org_auth = self.owner.organization.get_organization_authorization(user)
+            if repo_auth.role < org_auth.role:
+                return org_auth
 
-        return get
+        return repo_auth
 
     def get_absolute_url(self):
         return "{}dashboard/{}/{}/".format(

--- a/bothub/common/models.py
+++ b/bothub/common/models.py
@@ -911,13 +911,12 @@ class Repository(models.Model):
         )
         if self.owner.is_organization:
             org_auth = self.owner.organization.get_organization_authorization(user)
-            
+
             # Excluding ROLE_TRANSLATE as it does not correspond to the same role in the client app (connect).
             # todo: update this conditional with corresponding role rule
-            if repo_auth.role < org_auth.role\
-                and org_auth.role < RepositoryAuthorization.ROLE_TRANSLATE:
-                    repo_auth.role = org_auth.role
-                    repo_auth.save(update_fields=['role'])
+            if repo_auth.role < org_auth.role and org_auth.role < RepositoryAuthorization.ROLE_TRANSLATE:
+                repo_auth.role = org_auth.role
+                repo_auth.save(update_fields=['role'])
         return repo_auth
 
     def get_absolute_url(self):

--- a/bothub/common/tests.py
+++ b/bothub/common/tests.py
@@ -559,8 +559,8 @@ class RepositoryAuthorizationTestCase(TestCase):
         )
         self.organization = Organization.objects.create(name="Weni")
         self.organization_repository = Repository.objects.create(
-            owner=self.organization, 
-            name="Organization Repository", 
+            owner=self.organization,
+            name="Organization Repository",
             slug="organization_repository"
         )
 
@@ -692,8 +692,8 @@ class RepositoryAuthorizationTestCase(TestCase):
         self.assertTrue(authorization_user.can_contribute)
 
     def test_organization_auth_over_repository_auth(self):
-        """ 
-        Tests that a User's authorization role is of the highest level possible in a Repository, 
+        """
+        Tests that a User's authorization role is of the highest level possible in a Repository,
         either using the RepositoryAuthorization or the OrganizationAuthorization.
         The expected behavior is that the organization's authorization role should be passed to the repository's authorization for that user.
         """
@@ -709,7 +709,7 @@ class RepositoryAuthorizationTestCase(TestCase):
         collaborator_organization_auth = self.organization.organization_authorizations.create(
             user=self.collaborator, role=initial_organization_role
         )
-        
+
         # Validate that their access level corresponds to their role in the Organization and not the Repository, as it is higher at this point.
         user_authorization = self.organization_repository.get_user_authorization(self.collaborator)
         self.assertEqual(user_authorization.role, collaborator_organization_auth.role)
@@ -717,7 +717,7 @@ class RepositoryAuthorizationTestCase(TestCase):
         # Lower their level inside the Organization
         collaborator_organization_auth.role = OrganizationAuthorization.ROLE_NOT_SETTED
         collaborator_organization_auth.save()
-        
+
         # Validate that the repository authorization level was updated.
         collaborator_repository_auth.refresh_from_db()
         self.assertEqual(collaborator_repository_auth.role, initial_organization_role)
@@ -726,12 +726,12 @@ class RepositoryAuthorizationTestCase(TestCase):
         user_authorization = self.organization_repository.get_user_authorization(self.collaborator)
         self.assertEqual(user_authorization.role, collaborator_repository_auth.role)
 
-        ## Verify that org auth with (role >= 4) will not update the repository's authorization
-        
+        # Verify that org auth with (role >= 4) will not update the repository's authorization
+
         # Set user's role to ROLE_TRANSLATE level at the Organization
         collaborator_organization_auth.role = OrganizationAuthorization.ROLE_TRANSLATE
         collaborator_organization_auth.save()
-        
+
         user_authorization = self.organization_repository.get_user_authorization(self.collaborator)
         self.assertEqual(user_authorization.role, collaborator_repository_auth.role)
 

--- a/bothub/common/tests.py
+++ b/bothub/common/tests.py
@@ -695,7 +695,11 @@ class RepositoryAuthorizationTestCase(TestCase):
         """ 
         Tests that a User's authorization role is of the highest level possible in a Repository, 
         either using the RepositoryAuthorization or the OrganizationAuthorization.
+        The expected behavior is that the organization's authorization role should be passed to the repository's authorization for that user.
         """
+
+        # The role that the user should inherit from the organization authorization inside the repository.
+        initial_organization_role = OrganizationAuthorization.ROLE_ADMIN
 
         # Set user's role to a low level at the Repository
         collaborator_repository_auth, created = RepositoryAuthorization.objects.get_or_create(
@@ -703,24 +707,34 @@ class RepositoryAuthorizationTestCase(TestCase):
         )
         # Set user's role to a high level at the Organization
         collaborator_organization_auth = self.organization.organization_authorizations.create(
-            user=self.collaborator, role=OrganizationAuthorization.ROLE_ADMIN
+            user=self.collaborator, role=initial_organization_role
         )
         
         # Validate that their access level corresponds to their role in the Organization and not the Repository, as it is higher at this point.
-        repository_auth = self.organization_repository.get_user_authorization(self.collaborator)
-        self.assertEqual(repository_auth.role, collaborator_organization_auth.role)
+        user_authorization = self.organization_repository.get_user_authorization(self.collaborator)
+        self.assertEqual(user_authorization.role, collaborator_organization_auth.role)
 
         # Lower their level inside the Organization
         collaborator_organization_auth.role = OrganizationAuthorization.ROLE_NOT_SETTED
         collaborator_organization_auth.save()
         
-        # Validate that the repository authorization level is the same as before, i.e, it was not overwritten.
+        # Validate that the repository authorization level was updated.
         collaborator_repository_auth.refresh_from_db()
-        self.assertEqual(collaborator_repository_auth.role, RepositoryAuthorization.ROLE_USER)
+        self.assertEqual(collaborator_repository_auth.role, initial_organization_role)
 
         # Validate that the user's level is now the Repository's and not the Organization's, as it is higher.
-        repository_auth = self.organization_repository.get_user_authorization(self.collaborator)
-        self.assertEqual(repository_auth.role, collaborator_repository_auth.role)
+        user_authorization = self.organization_repository.get_user_authorization(self.collaborator)
+        self.assertEqual(user_authorization.role, collaborator_repository_auth.role)
+
+        ## Verify that org auth with (role >= 4) will not update the repository's authorization
+        
+        # Set user's role to ROLE_TRANSLATE level at the Organization
+        collaborator_organization_auth.role = OrganizationAuthorization.ROLE_TRANSLATE
+        collaborator_organization_auth.save()
+        
+        user_authorization = self.organization_repository.get_user_authorization(self.collaborator)
+        self.assertEqual(user_authorization.role, collaborator_repository_auth.role)
+
 
 class RepositoryVersionTrainingTestCase(TestCase):
     def setUp(self):


### PR DESCRIPTION
- Updates `bothub.common.models.Repository.get_user_authorization` method with rule that overwrites the repository authorization role with the organization's authorization role if the latter is lower than RepositoryAuthorization.ROLE_TRANSLATE.
- Create method validation test