### PR TITLE
Hotfix/update RepositoryAuthorization.get_role

### DIFF
--- a/bothub/common/models.py
+++ b/bothub/common/models.py
@@ -2020,26 +2020,9 @@ class RepositoryAuthorization(models.Model):
     @property
     def get_role(self):
         if self.role < RepositoryAuthorization.ROLE_USER and self.user:
-            org = (
-                self.user.organization_user_authorization.exclude(
-                    role=RepositoryAuthorization.ROLE_NOT_SETTED
-                )
-                .filter(
-                    Q(
-                        organization__in=RepositoryAuthorization.objects.filter(
-                            repository=self.repository,
-                            user__in=self.user.organization_user_authorization.exclude(
-                                role=OrganizationAuthorization.ROLE_NOT_SETTED
-                            ).values_list("organization", flat=True),
-                        )
-                        .exclude(role=OrganizationAuthorization.ROLE_NOT_SETTED)
-                        .order_by("-role")
-                        .values_list("user")
-                    )
-                )
-                .order_by("-role")
-            ).first()
-            return org.role if org else RepositoryAuthorization.LEVEL_NOTHING
+            # Get role directly from repository
+            auth = self.repository.get_user_authorization(self.user)
+            return auth.role
         return self.role
 
     @property


### PR DESCRIPTION
The model property contained an outdated business rule that allowed users to inherit the authorization role from any linked Organizations that had permission to access the repository.
The updated property uses the repository's get_user_authorization method, instead of searching for a higher authorization within the users' organizations.
